### PR TITLE
Update required request data for scraping

### DIFF
--- a/api/app/shared/models/scrape.py
+++ b/api/app/shared/models/scrape.py
@@ -1,19 +1,23 @@
 from datetime import datetime
 from typing import Any
 from pydantic import BaseModel, HttpUrl
-from app.shared.models.html import HtmlNode
+
+
+class NodeOutput(BaseModel):
+    location: str
+    key: str
 
 
 # TODO: This is not the finalized model but for now it'll work
 class RetrievalInstruction(BaseModel):
-    property_name: str
-    source_node: HtmlNode
-    action: str
+    node_query: str
+    output: NodeOutput
+    flags: dict
 
 
 class ScrapeConfig(BaseModel):
     url: HttpUrl
-    retrieval_instructions: list
+    retrieval_instructions: list[RetrievalInstruction]
 
 
 class ScrapedDataset(BaseModel):


### PR DESCRIPTION
- Changed the ScrapeConfig and RetrievalInstructions based on conversations with Arman regarding SDK

NOTE: Front end will need to be updated to send this data back:
Example: User wants to put the body of a `<p></p>` tag into field "name"
```js
{
  url: "www.something.com",
  retrieval_instructions: [{
    node_query: "SCRAPE 1 p IF POSITION=1", // This will be provided in the tree by SDK
    output: {
      location: "body",
      key: "name"
    },
    flags: {}
  }]
}